### PR TITLE
Upgrade to Moq 4.20.69

### DIFF
--- a/Moq.SetupAsync.Tests/Moq.SetupAsync.Tests.csproj
+++ b/Moq.SetupAsync.Tests/Moq.SetupAsync.Tests.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/Moq.SetupAsync.Tests/SetupAsyncActionFixture.cs
+++ b/Moq.SetupAsync.Tests/SetupAsyncActionFixture.cs
@@ -7,48 +7,48 @@ namespace Moq.SetupAsync.Tests
     public class SetupAsyncActionFixture
     {
         [Fact]
-        public void SetupAsyncActionIsWaitable()
+        public async Task SetupAsyncActionCanBeAwaited()
         {
             var mock = new Mock<IFoo>();
             mock.SetupAsync(x => x.DoActionAsync());
 
-            mock.Object.DoActionAsync().Wait();
+            await mock.Object.DoActionAsync();
 
             mock.VerifyAll();
         }
 
         [Fact]
-        public void SetupAsyncActionWithOneArgIsWaitable()
+        public async Task SetupAsyncActionWithOneArgCanBeAwaited()
         {
             var mock = new Mock<IFoo>();
             mock.SetupAsync(x => x.DoActionAsync(It.IsAny<string>()));
 
-            mock.Object.DoActionAsync("any string").Wait();
+            await mock.Object.DoActionAsync("any string");
 
             mock.VerifyAll();
         }
 
         [Fact]
-        public void SetupAsyncActionIsVerifiable()
+        public async Task SetupAsyncActionIsVerifiable()
         {
             var mock = new Mock<IFoo>();
             mock.SetupAsync(x => x.DoActionAsync()).Verifiable();
             mock.Verify(x => x.DoActionAsync(), Times.Never);
 
-            mock.Object.DoActionAsync().Wait();
+            await mock.Object.DoActionAsync();
 
             mock.Verify(x => x.DoActionAsync(), Times.Once);
             mock.Verify();
         }
 
         [Fact]
-        public void SetupAsyncActionWithOneArgIsVerifiable()
+        public async Task SetupAsyncActionWithOneArgIsVerifiable()
         {
             var mock = new Mock<IFoo>();
             mock.SetupAsync(x => x.DoActionAsync(It.IsAny<string>())).Verifiable();
             mock.Verify(x => x.DoActionAsync("any string"), Times.Never);
 
-            mock.Object.DoActionAsync("any string").Wait();
+            await mock.Object.DoActionAsync("any string");
 
             mock.Verify(x => x.DoActionAsync("any string"), Times.Once);
             mock.Verify();
@@ -65,37 +65,37 @@ namespace Moq.SetupAsync.Tests
         }
 
         [Fact]
-        public void SetupAsyncActionWithCallback()
+        public async Task SetupAsyncActionWithCallback()
         {
             var mock = new Mock<IFoo>();
             var isCalled = false;
             mock.SetupAsync(x => x.DoActionAsync()).Callback(() => isCalled = true);
 
-            mock.Object.DoActionAsync().Wait();
+            await mock.Object.DoActionAsync();
 
             Assert.True(isCalled);
         }
 
         [Fact]
-        public void SetupAsyncActionWithOneArgWithCallback()
+        public async Task SetupAsyncActionWithOneArgWithCallback()
         {
             var mock = new Mock<IFoo>();
             var isCalled = false;
             mock.SetupAsync(x => x.DoActionAsync(It.IsAny<string>())).Callback<string>(s => isCalled = s == "any string");
 
-            mock.Object.DoActionAsync("any string").Wait();
+            await mock.Object.DoActionAsync("any string");
 
             Assert.True(isCalled);
         }
 
         [Fact]
-        public void SetupAsyncActionWithThrows()
+        public async Task SetupAsyncActionWithThrows()
         {
             var mock = new Mock<IFoo>();
             mock.SetupAsync(x => x.DoActionAsync()).Throws<ArgumentException>();
             var task = mock.Object.DoActionAsync();
 
-            Assert.ThrowsAsync<ArgumentException>(() => task).Wait();
+            await Assert.ThrowsAsync<ArgumentException>(() => task);
         }
 
         public interface IFoo

--- a/Moq.SetupAsync.Tests/SetupAsyncFuncFixture.cs
+++ b/Moq.SetupAsync.Tests/SetupAsyncFuncFixture.cs
@@ -7,48 +7,48 @@ namespace Moq.SetupAsync.Tests
     public class SetupAsyncFuncFixture
     {
         [Fact]
-        public void SetupAsyncFuncIsWaitable()
+        public async Task SetupAsyncFuncCanBeAwaited()
         {
             var mock = new Mock<IFoo>();
             mock.SetupAsync(x => x.ExecFuncAsync());
 
-            mock.Object.ExecFuncAsync().Wait();
+            await mock.Object.ExecFuncAsync();
 
             mock.VerifyAll();
         }
 
         [Fact]
-        public void SetupAsyncFuncWithOneArgIsWaitable()
+        public async Task SetupAsyncFuncWithOneArgCanBeAwaited()
         {
             var mock = new Mock<IFoo>();
             mock.SetupAsync(x => x.ExecFuncAsync(It.IsAny<string>()));
 
-            mock.Object.ExecFuncAsync("any string").Wait();
+            await mock.Object.ExecFuncAsync("any string");
 
             mock.VerifyAll();
         }
 
         [Fact]
-        public void SetupAsyncFuncIsVerifiable()
+        public async Task SetupAsyncFuncIsVerifiable()
         {
             var mock = new Mock<IFoo>();
             mock.SetupAsync(x => x.ExecFuncAsync()).Verifiable();
             mock.Verify(x => x.ExecFuncAsync(), Times.Never);
 
-            mock.Object.ExecFuncAsync().Wait();
+            await mock.Object.ExecFuncAsync();
 
             mock.Verify(x => x.ExecFuncAsync(), Times.Once);
             mock.Verify();
         }
 
         [Fact]
-        public void SetupAsyncFuncWithOneArgIsVerifiable()
+        public async Task SetupAsyncFuncWithOneArgIsVerifiable()
         {
             var mock = new Mock<IFoo>();
             mock.SetupAsync(x => x.ExecFuncAsync(It.IsAny<string>())).Verifiable();
             mock.Verify(x => x.ExecFuncAsync("any string"), Times.Never);
 
-            mock.Object.ExecFuncAsync("any string").Wait();
+            await mock.Object.ExecFuncAsync("any string");
 
             mock.Verify(x => x.ExecFuncAsync("any string"), Times.Once);
             mock.Verify();
@@ -65,25 +65,25 @@ namespace Moq.SetupAsync.Tests
         }
 
         [Fact]
-        public void SetupAsyncFuncReturnsNullByDefault()
+        public async Task SetupAsyncFuncReturnsNullByDefault()
         {
             var mock = new Mock<IFoo>();
             mock.SetupAsync(x => x.ExecFuncAsync());
 
-            Assert.Null(mock.Object.ExecFuncAsync().Result);
+            Assert.Null(await mock.Object.ExecFuncAsync());
         }
 
         [Fact]
-        public void SetupAsyncFuncWithStaticReturns()
+        public async Task SetupAsyncFuncWithStaticReturns()
         {
             var mock = new Mock<IFoo>();
             mock.SetupAsync(x => x.ExecFuncAsync()).Returns("custom return");
 
-            Assert.Equal("custom return", mock.Object.ExecFuncAsync().Result);
+            Assert.Equal("custom return", await mock.Object.ExecFuncAsync());
         }
 
         [Fact]
-        public void SetupAsyncFuncWithComputedReturns()
+        public async Task SetupAsyncFuncWithComputedReturns()
         {
             var mock = new Mock<IFoo>();
             var isCalled = false;
@@ -93,29 +93,29 @@ namespace Moq.SetupAsync.Tests
                 return "custom return";
             });
 
-            Assert.Equal("custom return", mock.Object.ExecFuncAsync().Result);
+            Assert.Equal("custom return", await mock.Object.ExecFuncAsync());
             Assert.True(isCalled);
         }
 
         [Fact]
-        public void SetupAsyncFuncWithOneArgWithReturnsThatDependsOnArg()
+        public async Task SetupAsyncFuncWithOneArgWithReturnsThatDependsOnArg()
         {
             var mock = new Mock<IFoo>();
             mock.SetupAsync(x => x.ExecFuncAsync(It.IsAny<string>())).Returns<string>(s => "hello " + s);
 
-            var result = mock.Object.ExecFuncAsync("any string").Result;
+            var result = await mock.Object.ExecFuncAsync("any string");
 
             Assert.Equal("hello any string", result);
         }
 
         [Fact]
-        public void SetupAsyncFuncWithThrows()
+        public async Task SetupAsyncFuncWithThrows()
         {
             var mock = new Mock<IFoo>();
             mock.SetupAsync(x => x.ExecFuncAsync()).Throws<ArgumentException>();
             var task = mock.Object.ExecFuncAsync();
 
-            Assert.ThrowsAsync<ArgumentException>(() => task).Wait();
+            await Assert.ThrowsAsync<ArgumentException>(() => task);
         }
 
         public interface IFoo

--- a/Moq.SetupAsync.sln
+++ b/Moq.SetupAsync.sln
@@ -1,11 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2000
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35327.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moq.SetupAsync", "Moq.SetupAsync\Moq.SetupAsync.csproj", "{274FBF44-A58E-4464-B6D0-089742C4944A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Moq.SetupAsync.Tests", "Moq.SetupAsync.Tests\Moq.SetupAsync.Tests.csproj", "{3B85E7AA-2C71-419B-9894-2AA790B604FC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moq.SetupAsync.Tests", "Moq.SetupAsync.Tests\Moq.SetupAsync.Tests.csproj", "{3B85E7AA-2C71-419B-9894-2AA790B604FC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Moq.SetupAsync/Language/Flow/SetupAsync.cs
+++ b/Moq.SetupAsync/Language/Flow/SetupAsync.cs
@@ -165,6 +165,26 @@ namespace Moq.Language.Flow
         {
             this.Setup.Verifiable(failMessage);
         }
+
+        public void Verifiable(Times times)
+        {
+            this.Setup.Verifiable(times);
+        }
+
+        public void Verifiable(Func<Times> times)
+        {
+            this.Setup.Verifiable(times);
+        }
+
+        public void Verifiable(Times times, string failMessage)
+        {
+            this.Setup.Verifiable(times, failMessage);
+        }
+
+        public void Verifiable(Func<Times> times, string failMessage)
+        {
+            this.Setup.Verifiable(times, failMessage);
+        }
     }
 
     public class SetupAsync<TMock, TResult> : ISetupAsync<TResult>
@@ -324,6 +344,26 @@ namespace Moq.Language.Flow
         public void Verifiable(string failMessage)
         {
             this.Setup.Verifiable(failMessage);
+        }
+
+        public void Verifiable(Times times)
+        {
+            this.Setup.Verifiable(times);
+        }
+
+        public void Verifiable(Func<Times> times)
+        {
+            this.Setup.Verifiable(times);
+        }
+
+        public void Verifiable(Times times, string failMessage)
+        {
+            this.Setup.Verifiable(times, failMessage);
+        }
+
+        public void Verifiable(Func<Times> times, string failMessage)
+        {
+            this.Setup.Verifiable(times, failMessage);
         }
     }
 }

--- a/Moq.SetupAsync/Moq.SetupAsync.csproj
+++ b/Moq.SetupAsync/Moq.SetupAsync.csproj
@@ -3,13 +3,13 @@
   <PropertyGroup>
     <PackageId>Talentsoft.Moq.SetupAsync</PackageId>
     <Title>Moq.SetupAsync</Title>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Authors>Mickaël Nivet</Authors>
     <Company>Talentsoft</Company>
     <Description>Extension for Moq that allow to easily mock async methods</Description>
     <PackageProjectUrl>https://github.com/TalentSoft/Moq.SetupAsync</PackageProjectUrl>
     <PackageTags>moq async task</PackageTags>
-    <TargetFrameworks>net45;net46;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
     <RootNamespace>Moq</RootNamespace>
   </PropertyGroup>
 
@@ -23,7 +23,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.8.2" />
+    <PackageReference Include="Moq" Version="4.20.69" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
That version of moq added new methods on IVerifies interface that impact that extension
Without implementing the new methods the extension didn’t work on that version and newer ones of moq.